### PR TITLE
Test empty file for resumable media issue repro

### DIFF
--- a/tests/system/requests/test_upload.py
+++ b/tests/system/requests/test_upload.py
@@ -32,6 +32,8 @@ ICO_FILE = os.path.realpath(os.path.join(DATA_DIR, u"favicon.ico"))
 IMAGE_FILE = os.path.realpath(os.path.join(DATA_DIR, u"image1.jpg"))
 ICO_CONTENT_TYPE = u"image/x-icon"
 JPEG_CONTENT_TYPE = u"image/jpeg"
+EMPTY_FILE = os.path.realpath(os.path.join(DATA_DIR, u"empty.txt"))
+PLAIN_TEXT_TYPE = u"text/plain"
 BYTES_CONTENT_TYPE = u"application/octet-stream"
 BAD_CHUNK_SIZE_MSG = (
     b"Invalid request.  The number of bytes uploaded is required to be equal "
@@ -460,6 +462,42 @@ class TestResumableUploadUnknownSize(object):
                 stream,
                 metadata,
                 ICO_CONTENT_TYPE,
+                stream_final=False,
+            )
+            # Make sure ``initiate`` succeeded and did not mangle the stream.
+            check_initiate(response, upload, stream, authorized_transport, metadata)
+            # Make sure total bytes was never set.
+            assert upload.total_bytes is None
+            # Make the **ONLY** request.
+            response = upload.transmit_next_chunk(authorized_transport)
+            self._check_range_sent(response, 0, total_bytes - 1, total_bytes)
+            check_response(response, blob_name, total_bytes=total_bytes)
+            # Download the content to make sure it's "working as expected".
+            stream.seek(0)
+            actual_contents = stream.read()
+            check_content(blob_name, actual_contents, authorized_transport)
+            # Make sure the upload is tombstoned.
+            check_tombstoned(upload, authorized_transport)
+
+    def test_empty_size(self, authorized_transport, cleanup):
+        blob_name = os.path.basename(EMPTY_FILE)
+        chunk_size = resumable_media.UPLOAD_CHUNK_SIZE
+        # Make sure to clean up the uploaded blob when we are done.
+        cleanup(blob_name, authorized_transport)
+        check_does_not_exist(authorized_transport, blob_name)
+        # Make sure the blob is smaller than the chunk size.
+        total_bytes = os.path.getsize(EMPTY_FILE)
+        assert total_bytes < chunk_size
+        # Create the actual upload object.
+        upload = resumable_requests.ResumableUpload(utils.RESUMABLE_UPLOAD, chunk_size)
+        # Initiate the upload.
+        metadata = {u"name": blob_name}
+        with open(EMPTY_FILE, u"rb") as stream:
+            response = upload.initiate(
+                authorized_transport,
+                stream,
+                metadata,
+                PLAIN_TEXT_TYPE,
                 stream_final=False,
             )
             # Make sure ``initiate`` succeeded and did not mangle the stream.

--- a/tests/unit/test__upload.py
+++ b/tests/unit/test__upload.py
@@ -911,6 +911,15 @@ class Test_get_next_chunk(object):
         assert result1 == (len(data), b"", u"bytes */10")
         assert stream.tell() == len(data)
 
+    def test_success_zero_size(self):
+        data = b""
+        stream = io.BytesIO(data)
+        total_bytes = len(data)
+        chunk_size = 31
+        result0 = _upload.get_next_chunk(stream, chunk_size, total_bytes)
+        assert result0 == (0, b"", u"bytes */0")
+        assert stream.tell() == total_bytes
+
 
 class Test_get_content_range(object):
     def test_known_size(self):


### PR DESCRIPTION
Issue 62
Support non-buffered streams for 'ResumableUpload'.

Empty file upload is been tested.